### PR TITLE
Use pip version to receive latest image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,5 @@ runs:
   steps:
     - name: Install and configure Dotrun
       run: |
-        sudo rm -rf /etc/docker
-        sudo snap install dotrun
+        sudo pip3 install dotrun
       shell: bash


### PR DESCRIPTION
Avoid using snap version which is out of date, replace it with the pip version which will pull in the latest updates.